### PR TITLE
Fix docs.rs build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "docs_rs", feature(doc_auto_cfg))]
+#![cfg_attr(feature = "docs_rs", feature(doc_cfg))]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(feature = "std"), no_std)]


### PR DESCRIPTION
The `doc_auto_cfg` feature was merged into `doc_cfg`, see e.g. https://github.com/rust-lang/rust/pull/138907