### PR TITLE
Add support for bool arrays

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -176,6 +176,7 @@ impl<'de, T: Deserialize<'de>, S: Shape> Visitor<'de> for &mut Context<T, S> {
     }
 
     forward_visitors! {
+        fn visit_bool(bool);
         fn visit_i8(i8);
         fn visit_i16(i16);
         fn visit_i32(i32);

--- a/src/nalgebra.rs
+++ b/src/nalgebra.rs
@@ -15,8 +15,8 @@ impl<T> MakeNDim for DMatrix<T> {
     }
 }
 
-impl<'a, T: Scalar + Copy, R: Dim, C: Dim, S: RawStorage<T, R, C> + IsContiguous> NDim
-    for &'a Matrix<T, R, C, S>
+impl<T: Scalar + Copy, R: Dim, C: Dim, S: RawStorage<T, R, C> + IsContiguous> NDim
+    for &'_ Matrix<T, R, C, S>
 {
     type Shape = [usize; 2];
 
@@ -33,14 +33,14 @@ mod tests {
     use serde_json::json;
 
     macro_rules! roundtrip {
-        ($json:tt) => {
-            test_roundtrip::<DMatrix<i32>>(json!($json))
+        ($T:ty, $json:tt) => {
+            test_roundtrip::<$T>(json!($json))
         };
     }
 
     #[test]
     fn test_matrix() {
-        let matrix = roundtrip!([[1, 2, 3, 4], [5, 6, 7, 8]]).unwrap();
+        let matrix = roundtrip!(DMatrix<i32>, [[1, 2, 3, 4], [5, 6, 7, 8]]).unwrap();
         // not using `.shape()` to explicitly check that it's column-major
         assert_eq!((matrix.ncols(), matrix.nrows()), (2, 4));
         insta::assert_snapshot!(matrix);
@@ -48,31 +48,46 @@ mod tests {
 
     #[test]
     fn test_smaller_dimension_count() {
-        insta::assert_snapshot!(roundtrip!([1, 2, 3, 4]).unwrap_err());
+        insta::assert_snapshot!(roundtrip!(DMatrix<i32>, [1, 2, 3, 4]).unwrap_err());
     }
 
     #[test]
     fn test_larger_dimension_count() {
-        insta::assert_snapshot!(roundtrip!([
-            [[1, 2, 3, 4], [5, 6, 7, 8]],
-            [[9, 10, 11, 12], [13, 14, 15, 16]],
-            [[17, 18, 19, 20], [21, 22, 23, 24]]
-        ])
+        insta::assert_snapshot!(roundtrip!(
+            DMatrix<i32>,
+            [
+                [[1, 2, 3, 4], [5, 6, 7, 8]],
+                [[9, 10, 11, 12], [13, 14, 15, 16]],
+                [[17, 18, 19, 20], [21, 22, 23, 24]]
+            ]
+        )
         .unwrap_err());
     }
 
     #[test]
     fn test_inner_mismatch() {
-        insta::assert_snapshot!(roundtrip!([[1, 2, 3, 4], [5, 6, 8]]).unwrap_err());
+        insta::assert_snapshot!(roundtrip!(DMatrix<i32>, [[1, 2, 3, 4], [5, 6, 8]]).unwrap_err());
     }
 
     #[test]
     fn test_inner_mismatch_during_first_descent() {
-        insta::assert_snapshot!(roundtrip!([[1, [2], 3, 4], [5, 6, 7, 8]]).unwrap_err());
+        insta::assert_snapshot!(
+            roundtrip!(DMatrix<i32>, [[1, [2], 3, 4], [5, 6, 7, 8]]).unwrap_err()
+        );
+    }
+
+    #[test]
+    fn test_type_mismatch() {
+        insta::assert_snapshot!(roundtrip!(DMatrix<i32>, [[false]]).unwrap_err());
     }
 
     #[test]
     fn test_invalid_type() {
-        insta::assert_snapshot!(roundtrip!([[false]]).unwrap_err());
+        insta::assert_snapshot!(roundtrip!(DMatrix<i32>, [["a"]]).unwrap_err());
+    }
+
+    #[test]
+    fn test_bool_matrix() {
+        insta::assert_snapshot!(roundtrip!(DMatrix<bool>, [[true, false], [false, true]]).unwrap());
     }
 }

--- a/src/ndarray.rs
+++ b/src/ndarray.rs
@@ -127,7 +127,17 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_type() {
+    fn test_type_mismatch() {
         insta::assert_snapshot!(roundtrip!(ArrayD<i32>, [[[false]]]).unwrap_err());
+    }
+
+    #[test]
+    fn test_invalid_type() {
+        insta::assert_snapshot!(roundtrip!(ArrayD<i32>, [[["a"]]]).unwrap_err());
+    }
+
+    #[test]
+    fn test_bool_array() {
+        insta::assert_snapshot!(roundtrip!(ArrayD<bool>, [[[true, false], [false, true]]]).unwrap());
     }
 }

--- a/src/snapshots/serde_ndim__nalgebra__tests__bool_matrix.snap
+++ b/src/snapshots/serde_ndim__nalgebra__tests__bool_matrix.snap
@@ -1,0 +1,9 @@
+---
+source: src/nalgebra.rs
+expression: "roundtrip!(DMatrix<bool>, [[true, false], [false, true]]).unwrap()"
+---
+
+  ┌           ┐
+  │ true false │
+  │ false true │
+  └           ┘

--- a/src/snapshots/serde_ndim__nalgebra__tests__invalid_type.snap
+++ b/src/snapshots/serde_ndim__nalgebra__tests__invalid_type.snap
@@ -1,12 +1,11 @@
 ---
 source: src/nalgebra.rs
-expression: "roundtrip!([[false]]).unwrap_err()"
+expression: "roundtrip!([['a']]).unwrap_err()"
 ---
 
    | [
    |   [
- 3 |     false
-   |          ^ invalid type: boolean `false`, expected a sequence or a single number at line 3 column 9
+ 3 |     "a"
+   |        ^ invalid type: string "a", expected a sequence or a single number at line 3 column 7
    |   ]
    | ]
-

--- a/src/snapshots/serde_ndim__nalgebra__tests__type_mismatch.snap
+++ b/src/snapshots/serde_ndim__nalgebra__tests__type_mismatch.snap
@@ -1,0 +1,11 @@
+---
+source: src/nalgebra.rs
+expression: "roundtrip!([[false]]).unwrap_err()"
+---
+
+   | [
+   |   [
+ 3 |     false
+   |          ^ invalid type: boolean `false`, expected i32 at line 3 column 9
+   |   ]
+   | ]

--- a/src/snapshots/serde_ndim__ndarray__tests__bool_array.snap
+++ b/src/snapshots/serde_ndim__ndarray__tests__bool_array.snap
@@ -1,0 +1,6 @@
+---
+source: src/ndarray.rs
+expression: "roundtrip!(ArrayD<bool>, [[[true, false], [false, true]]]).unwrap()"
+---
+[[[true, false],
+  [false, true]]]

--- a/src/snapshots/serde_ndim__ndarray__tests__invalid_type.snap
+++ b/src/snapshots/serde_ndim__ndarray__tests__invalid_type.snap
@@ -1,14 +1,13 @@
 ---
 source: src/ndarray.rs
-expression: "roundtrip!(ArrayD < i32 >, [[[false]]]).unwrap_err()"
+expression: "roundtrip!(ArrayD<i32>, [[['a']]]).unwrap_err()"
 ---
 
    | [
    |   [
    |     [
- 4 |       false
-   |            ^ invalid type: boolean `false`, expected a sequence or a single number at line 4 column 11
+ 4 |       "a"
+   |          ^ invalid type: string "a", expected a sequence or a single number at line 4 column 9
    |     ]
    |   ]
    | ]
-

--- a/src/snapshots/serde_ndim__ndarray__tests__type_mismatch.snap
+++ b/src/snapshots/serde_ndim__ndarray__tests__type_mismatch.snap
@@ -1,0 +1,13 @@
+---
+source: src/ndarray.rs
+expression: "roundtrip!(ArrayD<i32>, [[[false]]]).unwrap_err()"
+---
+
+   | [
+   |   [
+   |     [
+ 4 |       false
+   |            ^ invalid type: boolean `false`, expected i32 at line 4 column 11
+   |     ]
+   |   ]
+   | ]


### PR DESCRIPTION
I stumbled the across the problem that deserialising into a bool array compiles but fails at runtime. This PR adds support for bool arrays - I need them for masks. But it might also be worth thinking about bounding the element type to the supported ones to catch the error earlier.

Would it also be possible to backport this change to v2.1.x and release a v2.1.1 patch (I'm still on ndarray v0.16)?