### PR TITLE
ci: Automate releases via release-plz with OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          command: release
+
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          command: release-pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,34 +4,15 @@ on:
   push:
     branches: [main]
 
-permissions:
-  pull-requests: write
-  contents: write
-
 jobs:
-  release-plz-release:
-    name: Release-plz release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: MarcoIeni/release-plz-action@v0.5
-        with:
-          command: release
-
-  release-plz-pr:
-    name: Release-plz PR
+  release-plz:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     concurrency:
-      group: release-plz-${{ github.ref }}
+      group: release-plz
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
@@ -39,5 +20,3 @@ jobs:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
       - uses: MarcoIeni/release-plz-action@v0.5
-        with:
-          command: release-pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,5 +18,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@stable
       - uses: MarcoIeni/release-plz-action@v0.5

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,2 @@
+[workspace]
+semver_check = true


### PR DESCRIPTION
Sets up [release-plz](https://github.com/MarcoIeni/release-plz) to handle the release process end-to-end, so future releases can be cut entirely from the GitHub mobile app.

## How it works

A single workflow runs on every push to `main`:

- If there are unreleased changes, release-plz opens (or updates) a "Release vX.Y.Z" PR with the `Cargo.toml` bump and a generated changelog.
- When that release PR is merged, release-plz tags the commit, creates a GitHub Release, and publishes to crates.io via OIDC trusted publishing — no API token in repo secrets.

## Version bump logic

`semver_check = true` runs [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks) against rustdoc JSON of the last published version:

- Breaking API change → forces **major** bump (automatic).
- Otherwise → defaults to **patch**. Edit the proposed version in the release PR body to make it minor when desired.

## Notes

- Workflow filename is `release.yml` to match the existing crates.io trusted publisher configuration.
- `cargo-semver-checks` is invoked by release-plz; it auto-installs the nightly toolchain it needs via the runner's pre-installed `rustup`.
- This PR itself does not bump the version; merging it just installs the automation. The next push to `main` will open the first release PR (proposing 2.2.1).